### PR TITLE
URL Cleanup

### DIFF
--- a/charts.d/apache.chart.sh
+++ b/charts.d/apache.chart.sh
@@ -151,7 +151,7 @@ apache_check() {
 	apache_get
 	if [ $? -ne 0 ]
 		then
-		echo >&2 "apache: cannot find stub_status on URL '${apache_url}'. Please set apache_url='http://apache.server:80/server-status?auto' in $confd/apache.conf"
+		echo >&2 "apache: cannot find stub_status on URL '${apache_url}'. Please set apache_url='https://apache.server:80/server-status?auto' in $confd/apache.conf"
 		return 1
 	fi
 

--- a/charts.d/mysql.chart.sh
+++ b/charts.d/mysql.chart.sh
@@ -1,6 +1,6 @@
 # no need for shebang - this file is loaded from charts.d.plugin
 
-# http://dev.mysql.com/doc/refman/5.0/en/server-status-variables.html
+# https://dev.mysql.com/doc/refman/5.0/en/server-status-variables.html
 #
 # https://dev.mysql.com/doc/refman/5.1/en/show-status.html
 # SHOW STATUS provides server status information (see Section 5.1.6, “Server Status Variables”).

--- a/charts.d/nginx.chart.sh
+++ b/charts.d/nginx.chart.sh
@@ -68,7 +68,7 @@ nginx_check() {
 	nginx_get
 	if [ $? -ne 0 ]
 		then
-		echo >&2 "nginx: cannot find stub_status on URL '${nginx_url}'. Please set nginx_url='http://nginx.server/stub_status' in $confd/nginx.conf"
+		echo >&2 "nginx: cannot find stub_status on URL '${nginx_url}'. Please set nginx_url='https://nginx.server/stub_status' in $confd/nginx.conf"
 		return 1
 	fi
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -9,7 +9,7 @@ DEBIAN_FRONTEND=noninteractive
 # some mirrors have issues, i skipped httpredir in favor of an eu mirror
 
 echo "deb http://ftp.nl.debian.org/debian/ jessie main" > /etc/apt/sources.list
-echo "deb http://security.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
+echo "deb http://security-cdn.debian.org/debian-security/ jessie/updates main" >> /etc/apt/sources.list
 
 # install dependencies for build
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1055,7 +1055,7 @@ OK. NetData is installed and it is running.
 By default netdata listens on all IPs on port ${NETDATA_PORT},
 so you can access it with:
 
-http://this.machine.ip:${NETDATA_PORT}/
+https://this.machine.ip:${NETDATA_PORT}/
 
 To stop netdata, just kill it, with:
 

--- a/plugins.d/alarm-email.sh
+++ b/plugins.d/alarm-email.sh
@@ -165,7 +165,7 @@ To: root
 Subject: ${hostname} ${status_message} - ${chart}.${name}
 Content-Type: text/html
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0; padding: 0;">
 <body style="font-family:'Helvetica Neue','Helvetica',Helvetica,Arial,sans-serif;font-size:14px;width:100%!important;min-height:100%;line-height:1.6;background:#f6f6f6;margin:0;padding:0">
 <table>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://ftp.nl.debian.org/debian/ (200) with 1 occurrences could not be migrated:  
   ([https](https://ftp.nl.debian.org/debian/) result SSLHandshakeException).
* http://security.debian.org/debian-security (302) with 1 occurrences could not be migrated:  
   ([https](https://security.debian.org/debian-security) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd) result ReadTimeoutException).
* http://apache.server:80/server-status?auto (UnknownHostException) with 1 occurrences migrated to:  
  https://apache.server:80/server-status?auto ([https](https://apache.server:80/server-status?auto) result UnknownHostException).
* http://nginx.server/stub_status (UnknownHostException) with 1 occurrences migrated to:  
  https://nginx.server/stub_status ([https](https://nginx.server/stub_status) result UnknownHostException).
* http://this.machine.ip (UnknownHostException) with 1 occurrences migrated to:  
  https://this.machine.ip ([https](https://this.machine.ip) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://dev.mysql.com/doc/refman/5.0/en/server-status-variables.html with 1 occurrences migrated to:  
  https://dev.mysql.com/doc/refman/5.0/en/server-status-variables.html ([https](https://dev.mysql.com/doc/refman/5.0/en/server-status-variables.html) result 301).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1 with 1 occurrences
* http://127.0.0.1:19999 with 1 occurrences
* http://127.0.0.1:80/server-status?auto with 1 occurrences
* http://127.0.0.1:80/stub_status with 1 occurrences
* http://localhost with 3 occurrences
* http://localhost/status with 2 occurrences
* http://localhost:8080/manager/status?XML=true with 1 occurrences
* http://www.w3.org/1999/xhtml with 1 occurrences