### PR TITLE
URL Cleanup

### DIFF
--- a/charts.d/apache.chart.sh
+++ b/charts.d/apache.chart.sh
@@ -157,7 +157,7 @@ apache_check() {
 	apache_get
 	if [ $? -ne 0 ]
 		then
-		error "cannot find stub_status on URL '${apache_url}'. Please set apache_url='http://apache.server:80/server-status?auto' in $confd/apache.conf"
+		error "cannot find stub_status on URL '${apache_url}'. Please set apache_url='https://apache.server:80/server-status?auto' in $confd/apache.conf"
 		return 1
 	fi
 

--- a/charts.d/mysql.chart.sh
+++ b/charts.d/mysql.chart.sh
@@ -6,7 +6,7 @@
 # GPL v3+
 #
 
-# http://dev.mysql.com/doc/refman/5.0/en/server-status-variables.html
+# https://dev.mysql.com/doc/refman/5.0/en/server-status-variables.html
 #
 # https://dev.mysql.com/doc/refman/5.1/en/show-status.html
 # SHOW STATUS provides server status information (see Section 5.1.6, “Server Status Variables”).

--- a/charts.d/nginx.chart.sh
+++ b/charts.d/nginx.chart.sh
@@ -74,7 +74,7 @@ nginx_check() {
 	nginx_get
 	if [ $? -ne 0 ]
 		then
-		error "cannot find stub_status on URL '${nginx_url}'. Please set nginx_url='http://nginx.server/stub_status' in $confd/nginx.conf"
+		error "cannot find stub_status on URL '${nginx_url}'. Please set nginx_url='https://nginx.server/stub_status' in $confd/nginx.conf"
 		return 1
 	fi
 

--- a/diagrams/build.sh
+++ b/diagrams/build.sh
@@ -5,7 +5,7 @@ cd "${path}" || exit 1
 
 if [ ! -f "plantuml.jar" ]
 then
-	echo >&2 "Please download 'plantuml.jar' from http://plantuml.com/ and put it the same folder with me."
+	echo >&2 "Please download 'plantuml.jar' from https://plantuml.com/ and put it the same folder with me."
 	exit 1
 fi
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -9,7 +9,7 @@ DEBIAN_FRONTEND=noninteractive
 # some mirrors have issues, i skipped httpredir in favor of an eu mirror
 
 echo "deb http://ftp.nl.debian.org/debian/ jessie main" > /etc/apt/sources.list
-echo "deb http://security.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
+echo "deb http://security-cdn.debian.org/debian-security/ jessie/updates main" >> /etc/apt/sources.list
 
 # install dependencies for build
 

--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -349,7 +349,7 @@ iscontainer() {
     fi
 
     # /proc/1/sched exposes the host's pid of our init !
-    # http://stackoverflow.com/a/37016302
+    # https://stackoverflow.com/a/37016302
     local pid=$( cat /proc/1/sched 2>/dev/null | head -n 1 | { IFS='(),#:' read name pid th threads; echo $pid; } )
     pid=$(( pid + 0 ))
     [ ${pid} -ne 1 ] && return 0
@@ -358,7 +358,7 @@ iscontainer() {
     [ ! -z "${container}" ] && return 0
 
     # docker creates /.dockerenv
-    # http://stackoverflow.com/a/25518345
+    # https://stackoverflow.com/a/25518345
     [ -f "/.dockerenv" ] && return 0
 
     # ubuntu and debian supply /bin/running-in-container

--- a/makeself/jobs/50-bash-4.4.install.sh
+++ b/makeself/jobs/50-bash-4.4.install.sh
@@ -2,7 +2,7 @@
 
 . $(dirname "${0}")/../functions.sh "${@}" || exit 1
 
-fetch "bash-4.4" "http://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz"
+fetch "bash-4.4" "https://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz"
 
 run ./configure \
 	--prefix=${NETDATA_INSTALL_PATH} \

--- a/makeself/makeself.sh
+++ b/makeself/makeself.sh
@@ -8,7 +8,7 @@
 # a small Shell script stub that uncompresses the archive to a temporary
 # directory and then executes a given script from withing that directory.
 #
-# Makeself home page: http://makeself.io/
+# Makeself home page: https://makeself.io/
 #
 # Version 2.0 is a rewrite of version 1.0 to make the code easier to read and maintain.
 #
@@ -71,7 +71,7 @@
 # (C) 1998-2017 by Stephane Peter <megastep@megastep.org>
 #
 # This software is released under the terms of the GNU GPL version 2 and above
-# Please read the license at http://www.gnu.org/copyleft/gpl.html
+# Please read the license at https://www.gnu.org/copyleft/gpl.html
 #
 
 MS_VERSION=2.3.1

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1167,7 +1167,7 @@ cat <<END
 netdata by default listens on all IPs on port ${NETDATA_PORT},
 so you can access it with:
 
-  ${TPUT_CYAN}${TPUT_BOLD}http://this.machine.ip:${NETDATA_PORT}/${TPUT_RESET}
+  ${TPUT_CYAN}${TPUT_BOLD}https://this.machine.ip:${NETDATA_PORT}/${TPUT_RESET}
 
 To stop netdata run:
 

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -1476,7 +1476,7 @@ Content-Type: text/html; encoding=${EMAIL_CHARSET}
 Content-Disposition: inline
 Content-Transfer-Encoding: 8bit
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0; padding: 0;">
 <body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; width: 100% !important; min-height: 100%; line-height: 1.6; background: #f6f6f6; margin:0; padding: 0;">
 <table>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://ftp.nl.debian.org/debian/ (200) with 1 occurrences could not be migrated:  
   ([https](https://ftp.nl.debian.org/debian/) result SSLHandshakeException).
* http://security.debian.org/debian-security (302) with 1 occurrences could not be migrated:  
   ([https](https://security.debian.org/debian-security) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd) result ReadTimeoutException).
* http://apache.server:80/server-status?auto (UnknownHostException) with 1 occurrences migrated to:  
  https://apache.server:80/server-status?auto ([https](https://apache.server:80/server-status?auto) result UnknownHostException).
* http://nginx.server/stub_status (UnknownHostException) with 1 occurrences migrated to:  
  https://nginx.server/stub_status ([https](https://nginx.server/stub_status) result UnknownHostException).
* http://this.machine.ip (UnknownHostException) with 1 occurrences migrated to:  
  https://this.machine.ip ([https](https://this.machine.ip) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz with 1 occurrences migrated to:  
  https://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz ([https](https://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz) result 200).
* http://makeself.io/ with 1 occurrences migrated to:  
  https://makeself.io/ ([https](https://makeself.io/) result 200).
* http://www.gnu.org/copyleft/gpl.html with 1 occurrences migrated to:  
  https://www.gnu.org/copyleft/gpl.html ([https](https://www.gnu.org/copyleft/gpl.html) result 200).
* http://dev.mysql.com/doc/refman/5.0/en/server-status-variables.html with 1 occurrences migrated to:  
  https://dev.mysql.com/doc/refman/5.0/en/server-status-variables.html ([https](https://dev.mysql.com/doc/refman/5.0/en/server-status-variables.html) result 301).
* http://plantuml.com/ with 1 occurrences migrated to:  
  https://plantuml.com/ ([https](https://plantuml.com/) result 302).
* http://stackoverflow.com/a/25518345 with 1 occurrences migrated to:  
  https://stackoverflow.com/a/25518345 ([https](https://stackoverflow.com/a/25518345) result 302).
* http://stackoverflow.com/a/37016302 with 1 occurrences migrated to:  
  https://stackoverflow.com/a/37016302 ([https](https://stackoverflow.com/a/37016302) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1 with 1 occurrences
* http://127.0.0.1:19999 with 1 occurrences
* http://127.0.0.1:80/server-status?auto with 1 occurrences
* http://127.0.0.1:80/stub_status with 1 occurrences
* http://localhost with 3 occurrences
* http://localhost/status with 2 occurrences
* http://localhost:8080/manager/status?XML=true with 1 occurrences
* http://www.w3.org/1999/xhtml with 1 occurrences