### PR TITLE
URL Cleanup

### DIFF
--- a/m4/jemalloc.m4
+++ b/m4/jemalloc.m4
@@ -6,7 +6,7 @@ dnl The ASF licenses this file to You under the Apache License, Version 2.0
 dnl (the "License"); you may not use this file except in compliance with
 dnl the License.  You may obtain a copy of the License at
 dnl
-dnl     http://www.apache.org/licenses/LICENSE-2.0
+dnl     https://www.apache.org/licenses/LICENSE-2.0
 dnl
 dnl Unless required by applicable law or agreed to in writing, software
 dnl distributed under the License is distributed on an "AS IS" BASIS,

--- a/m4/tcmalloc.m4
+++ b/m4/tcmalloc.m4
@@ -6,7 +6,7 @@ dnl The ASF licenses this file to You under the Apache License, Version 2.0
 dnl (the "License"); you may not use this file except in compliance with
 dnl the License.  You may obtain a copy of the License at
 dnl
-dnl     http://www.apache.org/licenses/LICENSE-2.0
+dnl     https://www.apache.org/licenses/LICENSE-2.0
 dnl
 dnl Unless required by applicable law or agreed to in writing, software
 dnl distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 2 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).